### PR TITLE
Update Dockerfiles and workflows to support Python 3.13 with trixie v…

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13"]
-        variant: ["bookworm-slim"]
+        variant: ["trixie-slim"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,20 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        variant: ["bookworm", "bookworm-slim"]
+        variant: ["bookworm", "bookworm-slim", "trixie", "trixie-slim"]
+        exclude:
+          - python-version: "3.11"
+            variant: "trixie"
+          - python-version: "3.11"
+            variant: "trixie-slim"
+          - python-version: "3.12"
+            variant: "trixie"
+          - python-version: "3.12"
+            variant: "trixie-slim"
+          - python-version: "3.13"
+            variant: "bookworm"
+          - python-version: "3.13"
+            variant: "bookworm-slim"
 
     steps:
       - name: Checkout repository

--- a/3.13/trixie-slim/Dockerfile
+++ b/3.13/trixie-slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM aliciousness/python-base:3.13-debian AS base
+FROM python:3.13-slim-trixie AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/3.13/trixie/Dockerfile
+++ b/3.13/trixie/Dockerfile
@@ -1,4 +1,4 @@
-FROM aliciousness/python-base:3.13 AS base
+FROM python:3.13-trixie  AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
This pull request updates the CI workflow and Dockerfile setup to support the Debian "trixie" release for Python 3.13, while also refining the matrix strategy for release builds to ensure only valid Python/Debian variant combinations are used. The most important changes are grouped below:

**CI Workflow Updates:**

* Added support for "trixie" and "trixie-slim" variants to the build matrix in `.github/workflows/release.yml`, and excluded invalid combinations of Python versions and Debian variants to prevent build failures.
* Changed the variant in `.github/workflows/pre-release.yml` for Python 3.13 from "bookworm-slim" to "trixie-slim".

**Dockerfile Updates:**

* Renamed `3.13/bookworm-slim/Dockerfile` to `3.13/trixie-slim/Dockerfile` and updated the base image from `aliciousness/python-base:3.13` to the official `python:3.13-slim-trixie`.
* Renamed `3.13/bookworm/Dockerfile` to `3.13/trixie/Dockerfile` and updated the base image from `aliciousness/python-base:3.13-debian` to the official `python:3.13-trixie`.